### PR TITLE
fix NrDsort.m in r-NSGA-II

### DIFF
--- a/PlatEMO/Algorithms/r-NSGA-II/NrDSort.m
+++ b/PlatEMO/Algorithms/r-NSGA-II/NrDSort.m
@@ -1,5 +1,5 @@
 function [FrontNo,MaxFNo] = NrDSort(PopObj,nSort,Points,W,delta)
-% Do non-r-dominated sorting by efficient non-dominated sort (ENS)
+% Do non-r-dominated sorting
 
 %------------------------------- Copyright --------------------------------
 % Copyright (c) 2018-2019 BIMK Group. You are free to use the PlatEMO for
@@ -29,7 +29,7 @@ function FrontNo = nrdsort(PopObj,g,w,delta)
     % cannot r-dominate the solutions having smaller Dist values than it
     [Dist,rank] = sort(Dist);
     PopObj      = PopObj(rank,:);
-    % Non-r-dominated sorting by ENS
+    % Non-r-dominated sorting
     [N,M]   = size(PopObj);
     FrontNo = inf(1,N);
     MaxFNo  = 0;
@@ -38,21 +38,31 @@ function FrontNo = nrdsort(PopObj,g,w,delta)
         for i = 1 : N
             if FrontNo(i) == inf
                 Dominated = false;
-                for j = i-1 : -1 : 1
-                    if FrontNo(j) == MaxFNo
+                for j = 1 : N
+                    if FrontNo(j) >= MaxFNo&&j ~= i
                         m = 1;
+                        % First check the Pareto dominance relationship
                         while m <= M && PopObj(i,m) >= PopObj(j,m)
                             m = m + 1;
                         end
-                        Dominated = m > M;
-                        if ~Dominated
-                            Dominated = (Dist(j)-Dist(i))./DistExtent < -delta;
-                        end
+                        Dominated = m > M;                       
                         if Dominated
-                            break;
+                           break;
                         end
                     end
                 end
+                % If the current solution is non-dominated one, then check the r-dominance relationship
+                if ~Dominated
+                    for j = i-1 : -1 : 1
+                        if FrontNo(j) == MaxFNo
+                            Dominated = (Dist(j)-Dist(i))./DistExtent < -delta;
+                            if Dominated
+                                break;
+                            end
+                        end
+                    end
+                end
+                
                 if ~Dominated
                     FrontNo(i) = MaxFNo;
                 end


### PR DESCRIPTION
Recently, I was working on MOEAs and found that PlatEMO is awesome. However, I found that the result of r-NSGA-II is a bit abnormal.

In r-dominance, according to the definition, if two individuals are Pareto non-dominated, then the dominance relation decided by the distance is checked between them. 

In the original version of nrdsort, the Pareto dominance relation is decided by ENS, which is not suitable here. In ENS, the individuals are sorted by the objective values. The first individual whose first objective value is minimal (The problems are minimized). Therefore, the first one must be the Pareto non-dominated solution. However, in nrdsort, all the individuals are sorted by the distance Dist. This means that the first individual may not be the Pareto non-domianted solution. In a sense, the smaller the distance, the closer it is to the reference point.

Here, I have modified the code in nrdsort. I have to admit that this modification is not efficient, but I think it is closer to r-NSGA-II than the previous version. Inside the outer loop, a loop is used to check Pareto dominance relation, and a loop is to check dominance relation by the distance.

Finally, this framework is very useful to me, thank you for all your work.
