### PR TITLE
Add three new algorithms

### DIFF
--- a/PlatEMO/Algorithms/Multi-objective optimization/MOEA-D-DCWV/MOEADDCWV.m
+++ b/PlatEMO/Algorithms/Multi-objective optimization/MOEA-D-DCWV/MOEADDCWV.m
@@ -1,0 +1,69 @@
+classdef MOEADDCWV < ALGORITHM
+% <multi/many> <real/binary/permutation>
+% MOEA/D with distribution control of weight vector set
+% p --- -1 --- The intermediate objective value
+
+%------------------------------- Reference --------------------------------
+% T. Takagi, K. Takadama, and H. Sato, A distribution control of weight 
+% vector set for multi-objective evolutionary algorithms, Proceedings of 
+% the Bio-inspired Information and Communication Technologies, Lecture 
+% Notes of the Institute for Computer Sciences, Social Informatics and 
+% Telecommunications Engineering, 2019, 70–80.
+%------------------------------- Copyright --------------------------------
+% Copyright (c) 2022 BIMK Group. You are free to use the PlatEMO for
+% research purposes. All publications which use this platform or any code
+% in the platform should acknowledge the use of "PlatEMO" and reference "Ye
+% Tian, Ran Cheng, Xingyi Zhang, and Yaochu Jin, PlatEMO: A MATLAB platform
+% for evolutionary multi-objective optimization [educational forum], IEEE
+% Computational Intelligence Magazine, 2017, 12(4): 73-87".
+%--------------------------------------------------------------------------
+
+% This function is written by Tomoaki Takagi
+
+    methods
+        function main(Algorithm,Problem)
+            %% Parameter setting
+            p = Algorithm.ParameterSet(-1);
+            
+            %% Generate the weight vectors
+            [W,Problem.N] = UniformPoint(Problem.N,Problem.M);
+            T = ceil(Problem.N/10);
+            
+            %% Set the weight vectors
+            [W,W0] = setWeight(W,p);
+            
+            %% Detect the neighbours of each solution
+            B = pdist2(W,W);
+            [~,B] = sort(B,2);
+            B = B(:,1:T);
+
+            %% Generate random population
+            Population = Problem.Initialization();
+            Z = min(Population.objs,[],1);
+
+            %% Optimization
+            while Algorithm.NotTerminated(Population)
+                if ~isempty(W0)
+                    W = updateWeight(Population.objs, W0);
+                end
+                % For each solution
+                for i = 1 : Problem.N
+                    % Choose the parents
+                    P = B(i,randperm(size(B,2)));
+                    
+                    % Generate an offspring
+                    Offspring = OperatorGAhalf(Population(P(1:2)));
+                    
+                    % Update the ideal and nadir point
+                    Z = min(Z,Offspring.obj);
+                    Zmax  = max(Population.objs,[],1);
+                    
+                    % Update the solutions in P by Modified Tchebycheff approach with normalization
+                    g_old = max(abs(Population(P).objs-repmat(Z,T,1))./repmat(Zmax-Z,T,1)./W(P,:),[],2);
+                    g_new = max(repmat(abs(Offspring.obj-Z)./(Zmax-Z),T,1)./W(P,:),[],2);
+                    Population(P(g_old>=g_new)) = Offspring;
+                end
+            end
+        end
+    end
+end

--- a/PlatEMO/Algorithms/Multi-objective optimization/MOEA-D-DCWV/setWeight.m
+++ b/PlatEMO/Algorithms/Multi-objective optimization/MOEA-D-DCWV/setWeight.m
@@ -1,0 +1,27 @@
+function [W,W0] = setWeight(W,p)
+% Set the weight vectors
+
+%------------------------------- Copyright --------------------------------
+% Copyright (c) 2022 BIMK Group. You are free to use the PlatEMO for
+% research purposes. All publications which use this platform or any code
+% in the platform should acknowledge the use of "PlatEMO" and reference "Ye
+% Tian, Ran Cheng, Xingyi Zhang, and Yaochu Jin, PlatEMO: A MATLAB platform
+% for evolutionary multi-objective optimization [educational forum], IEEE
+% Computational Intelligence Magazine, 2017, 12(4): 73-87".
+%--------------------------------------------------------------------------
+
+% This function is written by Tomoaki Takagi
+
+    if 0 <= p && p <= 1
+        %% Static approach
+        W0 = [];
+        M = size(W,2);
+        % Distribution control of weight vector set
+        TF = W < 1.0 / M;
+        W(TF) = W(TF) * p * M;
+        W(~TF) = 1.0 - (1.0 - W(~TF)) * (1.0 - p) * M / (M - 1);
+    else
+        %% Dynamic approach
+        W0 = W;
+    end
+end

--- a/PlatEMO/Algorithms/Multi-objective optimization/MOEA-D-DCWV/updateWeight.m
+++ b/PlatEMO/Algorithms/Multi-objective optimization/MOEA-D-DCWV/updateWeight.m
@@ -1,0 +1,26 @@
+function W = updateWeight(objs,W)
+% Update the weight vectors
+
+%------------------------------- Copyright --------------------------------
+% Copyright (c) 2022 BIMK Group. You are free to use the PlatEMO for
+% research purposes. All publications which use this platform or any code
+% in the platform should acknowledge the use of "PlatEMO" and reference "Ye
+% Tian, Ran Cheng, Xingyi Zhang, and Yaochu Jin, PlatEMO: A MATLAB platform
+% for evolutionary multi-objective optimization [educational forum], IEEE
+% Computational Intelligence Magazine, 2017, 12(4): 73-87".
+%--------------------------------------------------------------------------
+
+% This function is written by Tomoaki Takagi
+
+    % Calculate the intermediate objective value p
+    M = size(objs,2);
+    objs = normalize(objs,'range');
+    normP   = sqrt(sum(objs.^2,2));
+    CosineP = sum(objs./M,2).*sqrt(M)./normP;
+    [~,I]   = min(normP.*sqrt(1-CosineP.^2));
+    p       = normP(I)*CosineP(I) / sqrt(M);
+    % Distribution control of weight vector set
+    TF = W < 1.0 / M;
+    W(TF) = W(TF) * p * M;
+    W(~TF) = 1.0 - (1.0 - W(~TF)) * (1.0 - p) * M / (M - 1);
+end

--- a/PlatEMO/Algorithms/Multi-objective optimization/MOEA-D-PFE/MOEADPFE.m
+++ b/PlatEMO/Algorithms/Multi-objective optimization/MOEA-D-PFE/MOEADPFE.m
@@ -1,0 +1,91 @@
+classdef MOEADPFE < ALGORITHM
+% <multi/many> <real/binary/permutation>
+% MOEA/D with Pareto front estimation
+% phi   --- 0.1 --- The frequency of employing weight update
+% alpha --- 0.1 --- Alpha radius or threshold parameter
+
+%------------------------------- Reference --------------------------------
+% T. Takagi, K. Takadama, and H. Sato, A multi-objective evolutionary
+% algorithm using weight vector arrangement based on Pareto front
+% estimation, Transaction of the Japanese Society for Evolutionary
+% Computation, 2021, 12(2): 45-60. (in Japanese)
+%------------------------------- Copyright --------------------------------
+% Copyright (c) 2022 BIMK Group. You are free to use the PlatEMO for
+% research purposes. All publications which use this platform or any code
+% in the platform should acknowledge the use of "PlatEMO" and reference "Ye
+% Tian, Ran Cheng, Xingyi Zhang, and Yaochu Jin, PlatEMO: A MATLAB platform
+% for evolutionary multi-objective optimization [educational forum], IEEE
+% Computational Intelligence Magazine, 2017, 12(4): 73-87".
+%--------------------------------------------------------------------------
+
+% This function is written by Tomoaki Takagi
+
+    methods
+        function main(Algorithm,Problem)
+             %% Parameter setting
+            [phi,alpha] = Algorithm.ParameterSet(0.1,0.1);
+           
+            %% Generate validator and estimator
+            [validator,estimator] = generateFunctions(Problem.M,alpha);
+            
+            %% Generate the weight vectors
+            [W,Problem.N] = UniformPoint(Problem.N,Problem.M,'ILD');
+            T = ceil(Problem.N/10);
+            
+            %% Detect the neighbours of each solution
+            B = pdist2(W,W);
+            [~,B] = sort(B,2);
+            B = B(:,1:T);
+
+            %% Generate random population
+            Population = Problem.Initialization();
+            Z = min(Population.objs,[],1);
+            
+            %% Set weight update FE, bifurcation point, and external population
+            updateFE = ceil(phi*Problem.maxFE/Problem.N)*Problem.N;
+            BP = floor((Problem.maxFE-1)/updateFE)*updateFE;
+            EP = Population;
+            
+            %% Optimization
+            while Algorithm.NotTerminated(Population)
+                % For each solution
+                Offsprings(1:Problem.N) = SOLUTION();
+                for i = 1 : Problem.N
+                    % Choose the parents
+                    P = B(i,randperm(size(B,2)));
+                    
+                    % Generate an offspring
+                    Offsprings(i) = OperatorGAhalf(Population(P(1:2)));
+                    
+                    % Update the ideal point
+                    Z = min(Z,Offsprings(i).obj);
+                    
+                    % Update the solutions in P by Modified Tchebycheff approach
+                    g_old = max(abs(Population(P).objs-repmat(Z,T,1))./W(P,:),[],2);
+                    g_new = max(repmat(abs(Offsprings(i).obj-Z),T,1)./W(P,:),[],2);
+                    Population(P(g_old>=g_new)) = Offsprings(i);
+                end
+            
+                if Problem.FE <= BP
+                    EP = [EP,Offsprings];
+                    EP = EP(NDSort(EP.objs,1)==1);
+                    if length(EP) > 5000
+                        EP(1:length(EP)-5000) = [];
+                    end
+                    if ~mod(Problem.FE,updateFE)
+                        % Estimate the Pareto front
+                        objhat = estimatePF(EP.objs,validator,estimator);
+                        % Update the weight vectors
+                        [W,B] = updateWeight(EP.objs,objhat,Problem.N);
+                        % Update the population 
+                        obj = abs(EP.objs-repmat(Z,length(EP),1));
+                        for i = 1 : Problem.N
+                            [~,I] = min(max(obj./W(i,:),[],2));
+                            Population(i) = EP(I);
+                        end
+                    end
+                end
+            end
+        end
+    end
+end

--- a/PlatEMO/Algorithms/Multi-objective optimization/MOEA-D-PFE/dacefit.m
+++ b/PlatEMO/Algorithms/Multi-objective optimization/MOEA-D-PFE/dacefit.m
@@ -1,0 +1,358 @@
+function  [dmodel,perf] = dacefit(S,Y,regr,corr,theta0,lob,upb)
+%dacefit - Constrained non-linear least-squares fit of a given correlation
+%model to the provided data set and regression model
+%
+% Call
+%   [dmodel, perf] = dacefit(S, Y, regr, corr, theta0)
+%   [dmodel, perf] = dacefit(S, Y, regr, corr, theta0, lob, upb)
+%
+% Input
+% S, Y    : Data points (S(i,:), Y(i,:)), i = 1,...,m
+% regr    : Function handle to a regression model
+% corr    : Function handle to a correlation function
+% theta0  : Initial guess on theta, the correlation function parameters
+% lob,upb : If present, then lower and upper bounds on theta
+%           Otherwise, theta0 is used for theta
+%
+% Output
+% dmodel  : DACE model: a struct with the elements
+%    regr   : function handle to the regression model
+%    corr   : function handle to the correlation function
+%    theta  : correlation function parameters
+%    beta   : generalized least squares estimate
+%    gamma  : correlation factors
+%    sigma2 : maximum likelihood estimate of the process variance
+%    S      : scaled design sites
+%    Ssc    : scaling factors for design arguments
+%    Ysc    : scaling factors for design ordinates
+%    C      : Cholesky factor of correlation matrix
+%    Ft     : Decorrelated regression matrix
+%    G      : From QR factorization: Ft = Q*G' .
+%    perf   : struct with performance information. Elements
+%    nv     : Number of evaluations of objective function
+%    perf   : (q+2)*nv array, where q is the number of elements 
+%             in theta, and the columns hold current values of
+%                 [theta;  psi(theta);  type]
+%             |type| = 1, 2 or 3, indicate 'start', 'explore' or 'move'
+%             A negative value for type indicates an uphill step
+
+% hbn@imm.dtu.dk  
+% Last update September 3, 2002
+
+    % Check design points
+    [m,n] = size(S);  % number of design sites and their dimension
+    sY    = size(Y);
+    if min(sY) == 1
+        Y = Y(:);  
+        lY  = max(sY);  
+    else       
+        lY  = sY(1);
+    end
+    if m ~= lY
+        error('S and Y must have the same number of rows')
+    end
+    % Check correlation parameters if it is given
+    lth = length(theta0);
+    if nargin > 5  % optimization case
+        if length(lob) ~= lth || length(upb) ~= lth
+            error('theta0, lob and upb must have the same length')
+        end
+        if any(lob <= 0) || any(upb < lob)
+            error('The bounds must satisfy  0 < lob <= upb')
+        end
+    else  % given theta
+        if any(theta0 <= 0)
+            error('theta0 must be strictly positive')
+        end
+    end
+    % Normalize data
+    mS = mean(S);   sS = std(S);
+    mY = mean(Y);   sY = std(Y);
+    % 02.08.27: Check for 'missing dimension'
+    j = find(sS == 0);
+    if ~isempty(j)
+        sS(j) = 1;
+    end
+    j = find(sY == 0);
+    if  ~isempty(j)
+        sY(j) = 1;
+    end
+    S = (S - repmat(mS,m,1)) ./ repmat(sS,m,1);
+    Y = (Y - repmat(mY,m,1)) ./ repmat(sY,m,1);
+    % Calculate distances D between points
+    mzmax = m*(m-1) / 2;        % number of non-zero distances
+    ij    = zeros(mzmax, 2);  	% initialize matrix with indices
+    D     = zeros(mzmax, n);  	% initialize matrix with distances
+    LL    = 0;
+    for k = 1 : m-1
+        LL       = LL(end) + (1 : m-k);
+        ij(LL,:) = [repmat(k,m-k,1) (k+1:m)']; % indices for sparse matrix
+        D(LL,:)  = repmat(S(k,:),m-k,1)-S(k+1:m,:); % differences between points
+    end
+    %if min(sum(abs(D),2) ) == 0
+    %    error('Multiple design sites are not allowed')
+    %end
+    % Regression matrix
+    F      = feval(regr, S);  
+    [mF,p] = size(F);
+    if mF ~= m
+        error('number of rows in  F  and  S  do not match')
+    end
+    if p > mF 
+        error('least squares problem is underdetermined')
+    end
+    % parameters for objective function
+    par = struct('corr',corr,'regr',regr,'y',Y,'F',F,'D',D,'ij',ij,'scS',sS);
+    % Determine theta
+    if nargin > 5
+        % Bound constrained non-linear optimization
+        [theta, f, fit, perf] = boxmin(theta0, lob, upb, par);
+        if  isinf(f)
+            error('Bad parameter region.  Try increasing  upb')
+        end
+    else
+        % Given theta
+        theta   = theta0(:);   
+        [f,fit] = objfunc(theta, par);
+        perf    = struct('perf',[theta; f; 1], 'nv',1);
+        if  isinf(f)
+            error('Bad point.  Try increasing theta0')
+        end
+    end
+    % Return values
+    dmodel = struct('regr',regr,'corr',corr,'theta',theta.','beta',fit.beta,...
+                    'gamma',fit.gamma,'sigma2',sY.^2.*fit.sigma2,'S',S,'Ssc',[mS; sS],...
+                    'Ysc',[mY; sY],'C',fit.C,'Ft',fit.Ft,'G',fit.G);
+end
+
+function  [obj, fit] = objfunc(theta, par)
+    % Initialize
+    obj = inf; 
+    fit = struct('sigma2',NaN,'beta',NaN,'gamma',NaN,'C',NaN,'Ft',NaN,'G',NaN);
+    m   = size(par.F,1);
+    % Set up  R
+    r   = feval(par.corr, theta, par.D);
+    idx = find(r > 0);   o = (1 : m)';   
+    mu  = (10+m)*eps;
+    R   = sparse([par.ij(idx,1); o],[par.ij(idx,2); o],[r(idx); ones(m,1)+mu]);  
+    % Cholesky factorization with check for pos. def.
+    [C,rd] = chol(R);
+    if rd
+        return;
+    end
+    % Get least squares solution
+    C     = C';
+    Ft    = C \ par.F;
+    [Q,G] = qr(Ft,0);
+    if rcond(G) < 1e-10
+        % Check   F  
+        if cond(par.F) > 1e15 
+            error('F is too ill conditioned\nPoor combination of regression model and design sites')
+        else  % Matrix  Ft  is too ill conditioned
+            return 
+        end 
+    end
+    Yt   = C \ par.y;
+    beta = G \ (Q'*Yt);
+    rho  = Yt - Ft*beta;  sigma2 = sum(rho.^2)/m;
+    detR = prod( full(diag(C)) .^ (2/m) );
+    obj  = sum(sigma2) * detR;
+    if nargout > 1
+        fit = struct('sigma2',sigma2,'beta',beta,'gamma',rho'/C,'C',C,'Ft',Ft,'G',G');
+    end
+end
+
+function  [t,f,fit,perf] = boxmin(t0,lo,up,par)
+%BOXMIN  Minimize with positive box constraints
+
+    % Initialize
+    [t, f, fit, itpar] = start(t0, lo, up, par);
+    if  ~isinf(f)
+        % Iterate
+        p = length(t);
+        if  p <= 2
+            kmax = 2;
+        else
+            kmax = min(p,4);
+        end
+        for k = 1 : kmax
+            th = t;
+            [t, f, fit, itpar] = explore(t, f, fit, itpar, par);
+            [t, f, fit, itpar] = move(th, t, f, fit, itpar, par);
+        end
+    end
+    perf = struct('nv',itpar.nv, 'perf',itpar.perf(:,1:itpar.nv));
+end
+
+function [t,f,fit,itpar] = start(t0,lo,up,par)
+% Get starting point and iteration parameters
+
+    % Initialize
+    t  = t0(:);
+    lo = lo(:);
+    up = up(:);
+    p  = length(t);
+    D  = 2 .^((1:p)'/(p+2));
+    ee = find(up == lo);  % Equality constraints
+    if ~isempty(ee)
+        D(ee) = ones(length(ee),1);
+        t(ee) = up(ee); 
+    end
+    ng = find(t < lo | up < t);  % Free starting values
+    if ~isempty(ng)
+        t(ng) = (lo(ng) .* up(ng).^7).^(1/8);  % Starting point
+    end
+    ne = find(D ~= 1);
+    % Check starting point and initialize performance info
+    [f,fit] = objfunc(t,par);
+    nv      = 1;
+    itpar   = struct('D',D,'ne',ne,'lo',lo,'up',up,'perf',zeros(p+2,200*p),'nv',1);
+    itpar.perf(:,1) = [t; f; 1];
+    if isinf(f)    % Bad parameter region
+        return
+    end
+    if length(ng) > 1  % Try to improve starting guess
+        d0 = 16;  d1 = 2;   q = length(ng);
+        th = t;   fh = f;   jdom = ng(1);  
+        for k = 1 : q
+            j  = ng(k);
+            fk = fh;
+            tk = th;
+            DD = ones(p,1);  DD(ng) = repmat(1/d1,q,1);  DD(j) = 1/d0;
+            alpha = min(log(lo(ng) ./ th(ng)) ./ log(DD(ng))) / 5;
+            v = DD .^ alpha;
+            for rept = 1 : 4
+                tt = tk .* v; 
+                [ff, fitt] = objfunc(tt,par);  nv = nv+1;
+                itpar.perf(:,nv) = [tt; ff; 1];
+                if ff <= fk 
+                    tk = tt;
+                    fk = ff;
+                    if  ff <= f
+                        t   = tt;
+                        f   = ff;
+                        fit = fitt;
+                        jdom = j;
+                    end
+                else
+                    itpar.perf(end,nv) = -1;
+                    break
+                end
+            end
+        end % improve
+        % Update Delta  
+        if  jdom > 1
+            D([1 jdom]) = D([jdom 1]); 
+            itpar.D = D;
+        end
+    end % free variables
+    itpar.nv = nv;
+end
+
+function [t,f,fit,itpar] = explore(t,f,fit,itpar,par)
+% Explore step
+
+    nv = itpar.nv;
+    ne = itpar.ne;
+    for k = 1 : length(ne)
+        j  = ne(k);
+        tt = t;
+        DD = itpar.D(j);
+        if t(j) == itpar.up(j)
+            atbd  = 1;
+            tt(j) = t(j) / sqrt(DD);
+        elseif t(j) == itpar.lo(j)
+            atbd  = 1;
+            tt(j) = t(j) * sqrt(DD);
+        else
+            atbd  = 0;
+            tt(j) = min(itpar.up(j), t(j)*DD);
+        end
+        [ff,fitt] = objfunc(tt,par);
+        nv = nv+1;
+        itpar.perf(:,nv) = [tt; ff; 2];
+        if ff < f
+            t   = tt;
+            f   = ff;
+            fit = fitt;
+        else
+            itpar.perf(end,nv) = -2;
+            if ~atbd  % try decrease
+                tt(j) = max(itpar.lo(j), t(j)/DD);
+                [ff,fitt] = objfunc(tt,par);
+                nv = nv+1;
+                itpar.perf(:,nv) = [tt; ff; 2];
+                if ff < f
+                    t   = tt;
+                    f   = ff;
+                    fit = fitt;
+                else
+                    itpar.perf(end,nv) = -2;
+                end
+            end
+        end
+    end
+    itpar.nv = nv;
+end
+
+function [t,f,fit,itpar] = move(th,t,f,fit,itpar,par)
+% Pattern move
+
+    nv = itpar.nv;
+    p  = length(t);
+    v  = t ./ th;
+    if  all(v == 1)
+        itpar.D = itpar.D([2:p 1]).^.2;
+        return;
+    end
+    % Proper move
+    rept = 1;
+    while  rept
+        tt = min(itpar.up, max(itpar.lo, t .* v));  
+        [ff,fitt] = objfunc(tt,par); 
+        nv = nv+1;
+        itpar.perf(:,nv) = [tt; ff; 3];
+        if  ff < f
+            t   = tt;
+            f   = ff;
+            fit = fitt;
+            v   = v .^ 2;
+        else
+            itpar.perf(end,nv) = -3;
+            rept = 0;
+        end
+        if any(tt == itpar.lo | tt == itpar.up)
+            rept = 0;
+        end
+    end
+    itpar.nv = nv;
+    itpar.D  = itpar.D([2:p 1]).^.25;
+end
+
+function [r,dr] = corrgauss(theta,d)
+%CORRGAUSS  Gaussian correlation function,
+
+    [m,n] = size(d);  % number of differences and dimension of data
+    if length(theta) == 1
+        theta = repmat(theta,1,n);
+    elseif length(theta) ~= n
+        error('Length of theta must be 1 or %d',n)
+    end
+    td = d.^2 .* repmat(-theta(:).',m,1);
+    r  = exp(sum(td, 2));
+	dr = repmat(-2*theta(:).',m,1) .* d .* repmat(r,1,n);
+end
+
+function [f,df] = regpoly0(S)
+%REGPOLY0  Zero order polynomial regression function
+
+    f  = ones(size(S,1),1);
+	df = zeros(size(S,2),1);
+end
+
+function [f,df] = regpoly1(S)
+%REGPOLY1  First order polynomial regression function
+
+    f  = [ones(size(S,1),1),S];
+	df = [zeros(size(S,2),1),eye(size(S,2))];
+end

--- a/PlatEMO/Algorithms/Multi-objective optimization/MOEA-D-PFE/estimatePF.m
+++ b/PlatEMO/Algorithms/Multi-objective optimization/MOEA-D-PFE/estimatePF.m
@@ -1,0 +1,27 @@
+function objhat = estimatePF(obj,validator,estimator)
+% Estimate the Pareto front
+
+%------------------------------- Copyright --------------------------------
+% Copyright (c) 2022 BIMK Group. You are free to use the PlatEMO for
+% research purposes. All publications which use this platform or any code
+% in the platform should acknowledge the use of "PlatEMO" and reference "Ye
+% Tian, Ran Cheng, Xingyi Zhang, and Yaochu Jin, PlatEMO: A MATLAB platform
+% for evolutionary multi-objective optimization [educational forum], IEEE
+% Computational Intelligence Magazine, 2017, 12(4): 73-87".
+%--------------------------------------------------------------------------
+
+% This function is written by Tomoaki Takagi
+    
+    %% X as input, Y as output
+    obj = unique(normalize(obj,'range'),'rows');
+    Y = vecnorm(obj,1,2);
+    X = obj./Y;
+    
+    %% Generate the input W
+    W = UniformPoint(2e4,width(obj),'ILD');
+    W = validator(W,X);
+    
+    %% Estimate the objhat
+    objhat = estimator(W,X,Y);
+    objhat = objhat(NDSort(objhat,1)==1,:);
+end

--- a/PlatEMO/Algorithms/Multi-objective optimization/MOEA-D-PFE/generateFunctions.m
+++ b/PlatEMO/Algorithms/Multi-objective optimization/MOEA-D-PFE/generateFunctions.m
@@ -1,0 +1,55 @@
+function [validator, estimator] = generateFunctions(M,alpha)
+% Generate functions
+
+%------------------------------- Copyright --------------------------------
+% Copyright (c) 2022 BIMK Group. You are free to use the PlatEMO for
+% research purposes. All publications which use this platform or any code
+% in the platform should acknowledge the use of "PlatEMO" and reference "Ye
+% Tian, Ran Cheng, Xingyi Zhang, and Yaochu Jin, PlatEMO: A MATLAB platform
+% for evolutionary multi-objective optimization [educational forum], IEEE
+% Computational Intelligence Magazine, 2017, 12(4): 73-87".
+%--------------------------------------------------------------------------
+
+% This function is written by Tomoaki Takagi
+    
+    %% Generate validator
+    if M > 4 || isinf(alpha)
+        validator = @(W,X) W;
+    elseif M == 2
+        validator = @clusterValidator;
+    else
+        validator = @alphaShapeValidator;
+    end
+
+    %% Generate estimator
+    if ~isempty(ver('nnet'))
+        estimator = @(W,X,Y) W.*sim(newrbe(X',Y'),W')';
+    else
+        I = ones(1,M);
+        estimator = @(W,X,Y) W.*predictor(W, ...
+            dacefit(X,Y,'regpoly0','corrgauss',I,1e-3*I,1e3*I));
+    end
+    
+    %% Validator
+    i = 1:M-1;
+    A = [0*i;
+        tril(repmat(sqrt(1./i./(i+1)),M-1,1),-1)+diag(sqrt((i+1)./i))];
+    
+    function W = clusterValidator(W,X)
+        XA = sort(X*A);
+        T  = clusterdata(XA,'Criterion','distance','Cutoff',alpha);
+        XA = XA(setxor(uni(T),uni(T,'last')));
+        W  = W(mod(discretize(W*A,XA),2)==1,:);
+    end
+    
+    function W = alphaShapeValidator(W,X)
+        shp = alphaShape(X*A,alpha);
+        if alpha > min(alphaSpectrum(shp))
+            W = W(inShape(shp,W*A),:);
+        end
+    end
+end
+
+function ia = uni(varargin)
+    [~,ia] = unique(varargin{:});
+end

--- a/PlatEMO/Algorithms/Multi-objective optimization/MOEA-D-PFE/predictor.m
+++ b/PlatEMO/Algorithms/Multi-objective optimization/MOEA-D-PFE/predictor.m
@@ -1,0 +1,143 @@
+function [y,or1,or2,dmse] = predictor(x,dmodel)
+%PREDICTOR  Predictor for y(x) using the given DACE model.
+%
+% Call:   y = predictor(x, dmodel)
+%         [y, or] = predictor(x, dmodel)
+%         [y, dy, mse] = predictor(x, dmodel) 
+%         [y, dy, mse, dmse] = predictor(x, dmodel) 
+%
+% Input
+% x      : trial design sites with n dimensions.  
+%          For mx trial sites x:
+%          If mx = 1, then both a row and a column vector is accepted,
+%          otherwise, x must be an mx*n matrix with the sites stored
+%          rowwise.
+% dmodel : Struct with DACE model; see DACEFIT
+%
+% Output
+% y    : predicted response at x.
+% or   : If mx = 1, then or = gradient vector/Jacobian matrix of predictor
+%        otherwise, or is an vector with mx rows containing the estimated
+%                   mean squared error of the predictor
+% Three or four results are allowed only when mx = 1,
+% dy   : Gradient of predictor; column vector with  n elements
+% mse  : Estimated mean squared error of the predictor;
+% dmse : Gradient vector/Jacobian matrix of mse
+
+% hbn@imm.dtu.dk
+% Last update August 26, 2002
+ 
+    or1 = NaN; or2 = NaN; dmse = NaN;	% Default return values
+    if isnan(dmodel.beta)
+        error('DMODEL has not been found')
+    end
+    [m,n] = size(dmodel.S);     % number of design sites and number of dimensions
+    sx    = size(x);            % number of trial sites and their dimension
+    if min(sx) == 1 && n > 1    % Single trial point 
+        nx = max(sx);
+        if nx == n 
+            mx = 1;
+            x  = x(:).';
+        end
+    else
+        mx = sx(1);
+        nx = sx(2);
+    end
+    if nx ~= n
+        error('Dimension of trial sites should be %d',n)
+    end
+    % Normalize trial sites  
+    x = (x - repmat(dmodel.Ssc(1,:),mx,1)) ./ repmat(dmodel.Ssc(2,:),mx,1);
+    q = size(dmodel.Ysc,2);  % number of response functions
+    if mx == 1  % one site only
+        dx = repmat(x,m,1) - dmodel.S;  % distances to design sites
+        if nargout > 1                  % gradient/Jacobian wanted
+            [f,df] = feval(dmodel.regr, x);
+            [r,dr] = feval(dmodel.corr, dmodel.theta, dx);
+            % Scaled Jacobian
+            dy = (df * dmodel.beta).' + dmodel.gamma * dr;
+            % Unscaled Jacobian
+            or1 = dy .* repmat(dmodel.Ysc(2, :)', 1, nx) ./ repmat(dmodel.Ssc(2,:), q, 1);
+            if q == 1
+                % Gradient as a column vector
+                or1 = or1';
+            end
+            if nargout > 2  % MSE wanted
+                rt = dmodel.C \ r;
+                u = dmodel.Ft.' * rt - f.';
+                v = dmodel.G \ u;
+                or2 = repmat(dmodel.sigma2,mx,1) .* repmat((1 + sum(v.^2) - sum(rt.^2))',1,q);
+                if nargout > 3  % gradient/Jacobian of MSE wanted
+                    % Scaled gradient as a row vector
+                    Gv = dmodel.G' \ v;
+                    g = (dmodel.Ft * Gv - rt)' * (dmodel.C \ dr) - (df * Gv)';
+                    % Unscaled Jacobian
+                    dmse = repmat(2 * dmodel.sigma2',1,nx) .* repmat(g ./ dmodel.Ssc(2,:),q,1);
+                    if q == 1
+                    % Gradient as a column vector
+                    dmse = dmse';
+                    end
+                end
+            end
+        else  % predictor only
+            f = feval(dmodel.regr, x);
+            r = feval(dmodel.corr, dmodel.theta, dx);
+        end
+        % Scaled predictor
+        sy = f * dmodel.beta + (dmodel.gamma*r).';
+        % Predictor
+        y = (dmodel.Ysc(1,:) + dmodel.Ysc(2,:) .* sy)';
+	else  % several trial sites
+        % Get distances to design sites  
+        dx = zeros(mx*m,n);
+        kk = 1 : m;
+        for k = 1 : mx
+            dx(kk,:) = repmat(x(k,:),m,1) - dmodel.S;
+            kk = kk + m;
+        end
+        % Get regression function and correlation
+        f = feval(dmodel.regr, x);
+        r = feval(dmodel.corr, dmodel.theta, dx);
+        r = reshape(r, m, mx);
+        % Scaled predictor 
+        sy = f * dmodel.beta + (dmodel.gamma * r).';
+        % Predictor
+        y = repmat(dmodel.Ysc(1,:),mx,1) + repmat(dmodel.Ysc(2,:),mx,1) .* sy;
+        if nargout > 1	% MSE wanted
+            rt  = dmodel.C \ r;
+            u   = dmodel.G \ (dmodel.Ft.' * rt - f.');
+            or1 = repmat(dmodel.sigma2,mx,1) .* repmat((1 + sum(u.^2,1) - sum(rt.^2,1))',1,q);
+            if  nargout > 2
+                disp('WARNING from PREDICTOR.  Only  y  and  or1=mse  are computed')
+            end
+        end
+    end
+end
+
+function [r,dr] = corrgauss(theta,d)
+%CORRGAUSS  Gaussian correlation function,
+
+    [m,n] = size(d);  % number of differences and dimension of data
+    if length(theta) == 1
+        theta = repmat(theta,1,n);
+    elseif length(theta) ~= n
+        error('Length of theta must be 1 or %d',n)
+    end
+    td = d.^2 .* repmat(-theta(:).',m,1);
+    r  = exp(sum(td, 2));
+	dr = repmat(-2*theta(:).',m,1) .* d .* repmat(r,1,n);
+end
+
+function [f,df] = regpoly0(S)
+%REGPOLY0  Zero order polynomial regression function
+
+    f  = ones(size(S,1),1);
+	df = zeros(size(S,2),1);
+end
+
+function [f,df] = regpoly1(S)
+%REGPOLY1  First order polynomial regression function
+
+    f  = [ones(size(S,1),1),S];
+	df = [zeros(size(S,2),1),eye(size(S,2))];
+end

--- a/PlatEMO/Algorithms/Multi-objective optimization/MOEA-D-PFE/updateWeight.m
+++ b/PlatEMO/Algorithms/Multi-objective optimization/MOEA-D-PFE/updateWeight.m
@@ -1,0 +1,39 @@
+function [W,B] = updateWeight(obj,objhat,N)
+% Update the weight vectors
+
+%------------------------------- Copyright --------------------------------
+% Copyright (c) 2022 BIMK Group. You are free to use the PlatEMO for
+% research purposes. All publications which use this platform or any code
+% in the platform should acknowledge the use of "PlatEMO" and reference "Ye
+% Tian, Ran Cheng, Xingyi Zhang, and Yaochu Jin, PlatEMO: A MATLAB platform
+% for evolutionary multi-objective optimization [educational forum], IEEE
+% Computational Intelligence Magazine, 2017, 12(4): 73-87".
+%--------------------------------------------------------------------------
+
+% This function is written by Tomoaki Takagi
+
+    fmin = min(obj,[],1);
+    fmax = max(obj,[],1);
+    obj = unique([normalize(obj,'range');objhat],'rows');
+    
+    %% Select the representative objective vectors
+    LpNormD = pdist2(obj,obj,'minkowski',0.5);
+    Choose  = false(1,size(obj,1));
+    % Select the extreme objective vectors
+    [~,extreme]     = min(pdist2(obj,eye(size(obj,2)),'cosine'),[],1);
+    Choose(extreme) = true;
+    % Greedy inclusion distance-based subset slection
+    while sum(Choose) < N
+        Remain   = find(~Choose);
+        [~, rho] = max(min(LpNormD(Remain,Choose),[],2));
+        Choose(Remain(rho)) = true;
+    end
+    obj = obj(Choose,:);
+    
+    %% Update the weight vectors
+    W = obj.*repmat(fmax-fmin,N,1);
+    B = pdist2(W,W);
+    [~,B] = sort(B,2);
+    B = B(:,1:ceil(N/10));
+    W = W./vecnorm(W,1,2);
+end

--- a/PlatEMO/Algorithms/Multi-objective optimization/MOEA-D-VOV/MOEADVOV.m
+++ b/PlatEMO/Algorithms/Multi-objective optimization/MOEA-D-VOV/MOEADVOV.m
@@ -1,0 +1,87 @@
+classdef MOEADVOV < ALGORITHM
+% <multi/many> <real/binary/permutation>
+% MOEA/D with virtual objective vectors
+% G     ---  100 --- The weight update generation
+% C     ---    9 --- The weight update count
+% theta --- 0.02 --- Threshold
+
+%------------------------------- Reference --------------------------------
+% T. Takagi, K. Takadama, and H. Sato, Weight vector arrangement using
+% virtual objective vectors in decomposition-based MOEA, Proceedings of
+% the IEEE Congress on Evolutionary Computation, 2021, 1462-1469.
+%------------------------------- Copyright --------------------------------
+% Copyright (c) 2022 BIMK Group. You are free to use the PlatEMO for
+% research purposes. All publications which use this platform or any code
+% in the platform should acknowledge the use of "PlatEMO" and reference "Ye
+% Tian, Ran Cheng, Xingyi Zhang, and Yaochu Jin, PlatEMO: A MATLAB platform
+% for evolutionary multi-objective optimization [educational forum], IEEE
+% Computational Intelligence Magazine, 2017, 12(4): 73-87".
+%--------------------------------------------------------------------------
+
+% This function is written by Tomoaki Takagi
+
+    methods
+        function main(Algorithm,Problem)
+            %% Parameter setting
+            [G,C,theta] = Algorithm.ParameterSet(0.1,0.1);
+            
+            %% Generate the weight vectors
+            [W,Problem.N] = UniformPoint(Problem.N,Problem.M,'ILD');
+            T = ceil(Problem.N/10);
+            
+            %% Detect the neighbours of each solution
+            B = pdist2(W,W);
+            [~,B] = sort(B,2);
+            B = B(:,1:T);
+
+            %% Generate random population
+            Population = Problem.Initialization();
+            Z = min(Population.objs,[],1);
+            
+             %% Set bifurcation point and external population
+            BP = Problem.N * G * C;
+            EP = Population;
+
+            %% Optimization
+            while Algorithm.NotTerminated(Population)
+                % For each solution
+                Offsprings(1:Problem.N) = SOLUTION();
+                for i = 1 : Problem.N
+                    % Choose the parents
+                    P = B(i,randperm(size(B,2)));
+                    
+                    % Generate an offspring
+                    Offsprings(i) = OperatorGAhalf(Population(P(1:2)));
+                    
+                    % Update the ideal point
+                    Z = min(Z,Offsprings(i).obj);
+                    
+                    % Update the solutions in P by Modified Tchebycheff approach
+                    g_old = max(abs(Population(P).objs-repmat(Z,T,1))./W(P,:),[],2);
+                    g_new = max(repmat(abs(Offsprings(i).obj-Z),T,1)./W(P,:),[],2);
+                    Population(P(g_old>=g_new)) = Offsprings(i);
+                end
+                
+                if Problem.FE <= BP
+                    EP = [EP,Offsprings];
+                    EP = EP(NDSort(EP.objs,1)==1);
+                    if length(EP) > 5000
+                        EP(1:length(EP)-5000) = [];
+                    end
+                    if ~mod(ceil(Problem.FE/Problem.N),G)
+                        % Generate the virtual objective vectors
+                        VOV = generateVOV(EP.objs,theta);
+                        % Update the weight vectors
+                        [W,B] = updateWeight(EP.objs,VOV,Problem.N);
+                        % Update the population 
+                        obj = abs(EP.objs-repmat(Z,length(EP),1));
+                        for i = 1 : Problem.N
+                            [~,I] = min(max(obj./W(i,:),[],2));
+                            Population(i) = EP(I);
+                        end
+                    end
+                end
+            end
+        end
+    end
+end

--- a/PlatEMO/Algorithms/Multi-objective optimization/MOEA-D-VOV/generateVOV.m
+++ b/PlatEMO/Algorithms/Multi-objective optimization/MOEA-D-VOV/generateVOV.m
@@ -1,0 +1,34 @@
+function VOV = generateVOV(obj,theta)
+% Generate the virtual objective vectors
+
+%------------------------------- Copyright --------------------------------
+% Copyright (c) 2022 BIMK Group. You are free to use the PlatEMO for
+% research purposes. All publications which use this platform or any code
+% in the platform should acknowledge the use of "PlatEMO" and reference "Ye
+% Tian, Ran Cheng, Xingyi Zhang, and Yaochu Jin, PlatEMO: A MATLAB platform
+% for evolutionary multi-objective optimization [educational forum], IEEE
+% Computational Intelligence Magazine, 2017, 12(4): 73-87".
+%--------------------------------------------------------------------------
+
+% This function is written by Tomoaki Takagi
+    
+    obj    = normalize(obj,'range');
+    [N,M]  = size(obj);
+    [W,N2] = UniformPoint(2e4,M,'ILD');
+    VOV    = zeros(N2,M);
+    flag   = false(N2,1);
+    
+    normW   = sqrt(sum(W.^2,2));
+    normObj = sqrt(sum(obj.^2,2));
+    for i = 1 : N2
+        CosineVOV = sum(obj.*repmat(W(i,:),N,1),2)./normW(i,:)./normObj;
+        d2 = normObj.*sqrt(1-CosineVOV.^2);
+        [mind2,I] = min(d2);
+        d1 = normObj(I)*CosineVOV(I);
+        r = d1/norm(W(i,:));
+        
+        VOV(i,:) = W(i,:).*r;
+        flag(i)  = mind2 < theta;
+    end
+    VOV = VOV(flag,:);
+end

--- a/PlatEMO/Algorithms/Multi-objective optimization/MOEA-D-VOV/updateWeight.m
+++ b/PlatEMO/Algorithms/Multi-objective optimization/MOEA-D-VOV/updateWeight.m
@@ -1,0 +1,39 @@
+function [W,B] = updateWeight(obj,VOV,N)
+% Update the weight vectors
+
+%------------------------------- Copyright --------------------------------
+% Copyright (c) 2022 BIMK Group. You are free to use the PlatEMO for
+% research purposes. All publications which use this platform or any code
+% in the platform should acknowledge the use of "PlatEMO" and reference "Ye
+% Tian, Ran Cheng, Xingyi Zhang, and Yaochu Jin, PlatEMO: A MATLAB platform
+% for evolutionary multi-objective optimization [educational forum], IEEE
+% Computational Intelligence Magazine, 2017, 12(4): 73-87".
+%--------------------------------------------------------------------------
+
+% This function is written by Tomoaki Takagi
+
+    fmin = min(obj,[],1);
+    fmax = max(obj,[],1);
+    obj = unique([normalize(obj,'range');VOV],'rows');
+    
+    %% Select the representative objective vectors
+    LpNormD = pdist2(obj,obj,'minkowski',0.5);
+    Choose  = false(1,size(obj,1));
+    % Select the extreme objective vectors
+    [~,extreme]     = min(pdist2(obj,eye(size(obj,2)),'cosine'),[],1);
+    Choose(extreme) = true;
+    % Greedy inclusion distance-based subset selection
+    while sum(Choose) < N
+        Remain   = find(~Choose);
+        [~, rho] = max(min(LpNormD(Remain,Choose),[],2));
+        Choose(Remain(rho)) = true;
+    end
+    obj = obj(Choose,:);
+    
+    %% Update the weight vectors
+    W = obj.*repmat(fmax-fmin,N,1);
+    B = pdist2(W,W);
+    [~,B] = sort(B,2);
+    B = B(:,1:ceil(N/10));
+    W = W./vecnorm(W,1,2);
+end


### PR DESCRIPTION
Thank you for your wonderful work.
I would like to add three multi-objective evolutionary algorithms MOEA/D-DCWV, MOEA/D-VOV, and MOEA/D-PFE.
These algorithms are introduced in the following papers:

- T. Takagi, K. Takadama, and H. Sato, ``A Distribution Control of Weight Vector Set for Multi-objective Evolutionary Algorithms," Proceedings of the Bio-inspired Information and Communication Technologies (BICT2019), Lecture Notes of the Institute for Computer Sciences, Social Informatics and Telecommunications Engineering (LNICST), Vol. 289, Springer, Cham, pp. 70-80, 2019.
- T. Takagi, K. Takadama, and H. Sato, ``Weight Vector Arrangement Using Virtual Objective Vectors in Decomposition-based MOEA," Proceedings of the IEEE Congress on Evolutionary Computation (CEC2021), pp. 1462-1469, 2021.
- T. Takagi, K. Takadama, and H. Sato, ``A Multi-objective Evolutionary Algorithm Using Weight Vector Arrangement Based on Pareto Front Estimation," Transaction of the Japanese Society for Evolutionary Computation, Vol. 12, No. 2, pp. 45-60, 2021. (in Japanese)